### PR TITLE
release 7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+### 7.1.0 released 30-Oct-2023
+
+* fix: rockspecs for MacOS
+
+* feat: `iconv.new` now returns a second value in case of errors
+
+---
+
+### 7.0.0 released 17-Oct-2023
+
+* First release from its new Lunar Modules home

--- a/rockspecs/lua-iconv-7.1.0-1.rockspec
+++ b/rockspecs/lua-iconv-7.1.0-1.rockspec
@@ -1,5 +1,5 @@
 local package_name = "lua-iconv"
-local package_version = "dev"
+local package_version = "7.1.0"
 local rockspec_revision = "1"
 local github_account_name = "lunarmodules"
 local github_repo_name = package_name


### PR DESCRIPTION
* Release 7.1
* Updates the dev rockspec to pin to a tag, such that new rockspecs generated from it will not point to `master` but to the version tag.
* adds a CHANGELOG.md